### PR TITLE
feat: add recursive option for MCS file discovery

### DIFF
--- a/mcs_mea_analysis/discovery.py
+++ b/mcs_mea_analysis/discovery.py
@@ -12,12 +12,16 @@ from typing import Iterable, List
 from .config import CONFIG
 
 
-def iter_h5_files(base_dirs: Iterable[Path] | None = None, h5_subdir: str | None = None) -> Iterable[Path]:
+def iter_h5_files(
+    base_dirs: Iterable[Path] | None = None,
+    h5_subdir: str | None = None,
+    recursive: bool = False,
+) -> Iterable[Path]:
     """
     Iterate all .h5 files under each `<base_dir>/<h5_subdir>` directory.
 
     - If `<base_dir>/<h5_subdir>` is missing, skip quietly.
-    - Non-recursive listing (to mirror prior organization).
+    - `recursive=True` walks subdirectories; otherwise, only the top level is listed.
     """
     base_dirs = tuple(base_dirs) if base_dirs is not None else CONFIG.base_dirs
     h5_subdir = h5_subdir or CONFIG.h5_subdir
@@ -26,12 +30,23 @@ def iter_h5_files(base_dirs: Iterable[Path] | None = None, h5_subdir: str | None
         h5_dir = base / h5_subdir
         if not h5_dir.exists() or not h5_dir.is_dir():
             continue
-        for p in sorted(h5_dir.iterdir()):
-            if p.suffix.lower() == ".h5" and p.is_file():
-                yield p
+        if recursive:
+            for p in sorted(h5_dir.rglob("*.h5")):
+                if p.is_file():
+                    yield p
+        else:
+            for p in sorted(h5_dir.iterdir()):
+                if p.suffix.lower() == ".h5" and p.is_file():
+                    yield p
 
 
-def list_h5_files() -> List[Path]:
+def list_h5_files(
+    base_dirs: Iterable[Path] | None = None,
+    h5_subdir: str | None = None,
+    recursive: bool = False,
+) -> List[Path]:
     """Return a list of discovered .h5 files for convenience."""
-    return list(iter_h5_files())
+    return list(
+        iter_h5_files(base_dirs=base_dirs, h5_subdir=h5_subdir, recursive=recursive)
+    )
 


### PR DESCRIPTION
## Summary
- allow optional recursive search for MCS .h5 files
- expose recursive parameter via `list_h5_files`

## Testing
- `python -m py_compile mcs_mea_analysis/discovery.py`


------
https://chatgpt.com/codex/tasks/task_e_68beecc1ad34832e800d544605e86217