### PR TITLE
Add PyQt dependencies to MCS environment

### DIFF
--- a/environment_mcs.yml
+++ b/environment_mcs.yml
@@ -12,6 +12,8 @@ dependencies:
   - xarray
   - h5py
   - ipykernel
+  - pyqt
+  - pyqtgraph
   - pip
   - pip:
       - McsPyDataTools


### PR DESCRIPTION
## Summary
- add PyQt and PyQtGraph to `environment_mcs.yml`

## Testing
- `python - <<'PY'
import yaml
with open('environment_mcs.yml') as f:
    data=yaml.safe_load(f)
print(data['dependencies'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bef2245674832ebd7ae65e41878ae0